### PR TITLE
Update tests and allow test key from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 Go Quandl
-=========
+==================================================
 
 [![Build Status](https://travis-ci.org/DannyBen/quandl.svg?branch=master)](https://travis-ci.org/DannyBen/quandl) [![GoDoc](https://godoc.org/github.com/DannyBen/quandl?status.png)](http://godoc.org/github.com/DannyBen/quandl)
+
+---
 
 This library provides easy access to the 
 [Quandl API](https://www.quandl.com/help/api) 
@@ -10,21 +12,26 @@ using the Go programming language.
 The full documentation is at:  
 [godoc.org/github.com/DannyBen/quandl](http://godoc.org/github.com/DannyBen/quandl)
 
+---
+
 Install
--------
+--------------------------------------------------
 
 	$ go get github.com/DannyBen/quandl
 
+
 Features
---------
+--------------------------------------------------
 
 * Supports 3 call types to Quandl: `GetSymbol`, `GetList` and `GetSearch`.
 * Returns either a native [Go object](https://github.com/DannyBen/quandl/blob/master/quandlResponseTypes.go), or a raw (CSV/JSON/XML)
   response.
 * Built in cache handling.
 
+
 Usage
------
+--------------------------------------------------
+
 Basic usage looks like this:
 
 	quandl.ApiKey = "YOUR KEY"
@@ -53,3 +60,12 @@ More examples are in the
 [quandl_test file](https://github.com/DannyBen/quandl/blob/master/quandl_test.go)
 or in the 
 [official godoc documentation](http://godoc.org/github.com/DannyBen/quandl#pkg-examples)
+
+
+Development
+--------------------------------------------------
+
+Before running tests, set your API key in an environment variable.
+
+	$ export QUANDL_KEY=your_key_here
+	$ go test

--- a/quandl_test.go
+++ b/quandl_test.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"github.com/DannyBen/filecache"
 	"github.com/DannyBen/quandl"
+	"os"
 	"time"
 )
 
-var apiKey = "PUT_KEY_HERE"
+var apiKey = os.Getenv("QUANDL_KEY")
 
 // Main Functions
 
@@ -31,7 +32,7 @@ func ExampleGetSymbol() {
 	// Output:
 	// Symbol: AAPL, Row Count: 21
 	// Fifth column is named Close
-	// On 2014-01-30 the close price was 499.78
+	// On 2014-01-30 the close price was 499.782
 }
 
 func ExampleGetSymbolRaw() {
@@ -74,7 +75,7 @@ func ExampleGetList() {
 	}
 
 	// Output:
-	// 0 AAPL
+	// 0 FLWS
 }
 
 func ExampleGetSearch() {
@@ -115,7 +116,7 @@ func ExampleToColumns() {
 	fmt.Println(d)
 
 	// Output:
-	// [[2014-01-08 2014-01-07 2014-01-06] [543.46 540.04 543.93]]
+	// [[2014-01-08 2014-01-07 2014-01-06] [543.46 540.0375 543.93]]
 }
 
 func ExampleToNamedColumns() {
@@ -137,7 +138,7 @@ func ExampleToNamedColumns() {
 	fmt.Println(d["Date"], d["Close"])
 
 	// Output:
-	// [2014-01-07 2014-01-06] [540.04 543.93]
+	// [2014-01-07 2014-01-06] [540.0375 543.93]
 }
 
 // Column Converters
@@ -364,7 +365,7 @@ func ExampleSymbolResponse_ToColumns() {
 	fmt.Println(d)
 
 	// Output:
-	// [[2014-01-08 2014-01-07 2014-01-06] [543.46 540.04 543.93]]
+	// [[2014-01-08 2014-01-07 2014-01-06] [543.46 540.0375 543.93]]
 }
 
 func ExampleSymbolResponse_ToNamedColumns_1() {
@@ -386,7 +387,7 @@ func ExampleSymbolResponse_ToNamedColumns_1() {
 	fmt.Println(d["Date"], d["Adj. Close"])
 
 	// Output:
-	// [2014-01-07 2014-01-06] [75.561212341336 76.105492609478]
+	// [2014-01-07 2014-01-06] [73.451508457897 73.98093464899]
 }
 
 func ExampleSymbolResponse_ToNamedColumns_2() {
@@ -408,7 +409,7 @@ func ExampleSymbolResponse_ToNamedColumns_2() {
 	fmt.Println(d["date"], d["close"])
 
 	// Output:
-	// [2014-01-07 2014-01-06] [75.561212341336 76.105492609478]
+	// [2014-01-07 2014-01-06] [73.451508457897 73.98093464899]
 }
 
 // Options


### PR DESCRIPTION
Quandl has changed some of their response (e.g. higher precision in some cases) so, this PR:
- fixes all tests
- loads API Key from the environment variable `QUANDL_KEY`
