### PR TITLE
Test against later versions of Go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,4 @@
 language: go
-
+go:
+  - 1.4
+  - 1.6


### PR DESCRIPTION
Travis is defaulting ot 1.4.1, so it would be good to go ahead and test
against newer Go versions.
