### PR TITLE
Less fragile ExampleGetList test

### DIFF
--- a/quandl_test.go
+++ b/quandl_test.go
@@ -69,9 +69,9 @@ func ExampleGetList() {
 		panic(err)
 	}
 
-  for i, doc := range data.Docs {
-    fmt.Println(i, doc.SourceCode, doc.ColumnNames[1])
-  }
+	for i, doc := range data.Docs {
+		fmt.Println(i, doc.SourceCode, doc.ColumnNames[1])
+	}
 
 	// Output:
 	// 0 WIKI Open

--- a/quandl_test.go
+++ b/quandl_test.go
@@ -69,13 +69,14 @@ func ExampleGetList() {
 		panic(err)
 	}
 
-	for i, doc := range data.Docs {
-		fmt.Println(i, doc.Code)
-		break
-	}
+  for i, doc := range data.Docs {
+    fmt.Println(i, doc.SourceCode, doc.ColumnNames[1])
+  }
 
 	// Output:
-	// 0 CTRL
+	// 0 WIKI Open
+	// 1 WIKI Open
+	// 2 WIKI Open
 }
 
 func ExampleGetSearch() {


### PR DESCRIPTION
Test kept breaking since Quandl returns the symbols in a different order for some odd reason, so test now does not rely on the symbol in its output.
